### PR TITLE
Add grunt-cli to dev-dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Prerequisites: `node`.
 ```bash
 git clone git@github.com:STRML/Healthcare.gov-Marketplace.git # or download ZIP
 cd Healthcare.gov-Marketplace
-npm install -g grunt # Grunt is required for building
 npm install
 npm start # Starts local proxy server & launches browser
 ```

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "express": "~3.4.0"
   },
   "devDependencies": {
+    "grunt-cli": "~0.1.9",
     "grunt": "~0.4.1",
     "grunt-usemin": "~0.1.12",
     "grunt-contrib-jshint": "~0.6.4",


### PR DESCRIPTION
`npm start` will put ./node_modules/.bin/ in the $PATH making this
version of grunt accessible.

This eliminates the setup step `npm install -g grunt`.
